### PR TITLE
feat(#48): add FAQ and Terms pages with accordion UI for FAQ

### DIFF
--- a/frontend/app/help/page.tsx
+++ b/frontend/app/help/page.tsx
@@ -1,0 +1,29 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
+
+export default function HelpPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12 text-theme-text">
+      <h1 className="text-3xl font-bold mb-8">Frequently Asked Questions</h1>
+      <Accordion type="single" collapsible className="w-full space-y-2">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>What is GreenCode?</AccordionTrigger>
+          <AccordionContent>
+            GreenCode is a competitive coding platform focused on low-power, efficient programming challenges.
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Do I need an account to submit code?</AccordionTrigger>
+          <AccordionContent>
+            Yes. You need to create an account to track submissions and participate in leaderboards.
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-3">
+          <AccordionTrigger>What languages are supported?</AccordionTrigger>
+          <AccordionContent>
+            Currently, we support C and Python — with more coming soon.
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  )
+}

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,0 +1,29 @@
+export default function TermsPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12 text-theme-text">
+      <h1 className="text-3xl font-bold mb-6"> GreenCode Terms of Use</h1>
+      <p className="mb-4 text-muted-foreground">
+        By using GreenCode, you agree to the following terms and conditions...
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">1. Use of the Platform</h2>
+      <p className="mb-4 text-muted-foreground">
+        You may use GreenCode for personal and educational purposes only unless otherwise authorized.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">2. User Content</h2>
+      <p className="mb-4 text-muted-foreground">
+        By submitting code, you grant us the right to store and evaluate it for performance and quality scoring.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-2">3. Termination</h2>
+      <p className="mb-4 text-muted-foreground">
+        We reserve the right to suspend accounts or remove content that violates our guidelines.
+      </p>
+
+      <p className="text-muted-foreground mt-8">
+        These terms are subject to change.
+      </p>
+    </div>
+  )
+}

--- a/frontend/components/ui/accordion.tsx
+++ b/frontend/components/ui/accordion.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDownIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }


### PR DESCRIPTION
added a page with FAQ, used a new shadcn component ( run npx shadcn-ui@latest add accordion ) to fold out FAQ questions.

also added a page for Terms of our website

