### PR TITLE
Test framework + example wrapper + example submission

### DIFF
--- a/prototype/skeleton/C/datastructs.c
+++ b/prototype/skeleton/C/datastructs.c
@@ -1,0 +1,16 @@
+// deserialiser.c
+
+/** IMPORTANT:
+ * IF THIS FILE IS MODIFIED IN ANY WAY,
+ * PROPAGATE MODIFICATIONS TO SERIALISER AND DESERIALISER
+ */
+
+/**
+ * Library containing all sorts of data structures that can be used in
+ * the exercise
+ */
+
+struct IntLinkedListNode {
+    int val;
+    struct IntLinkedListNode *next;
+};

--- a/prototype/skeleton/C/deserialiser.c
+++ b/prototype/skeleton/C/deserialiser.c
@@ -1,0 +1,78 @@
+// deserialiser.c
+
+/** IMPORTANT:
+ * IF THIS FILE IS MODIFIED IN ANY WAY,
+ * PROPAGATE MODIFICATIONS TO serialiser.c/.h
+ */
+
+/**
+ * Contains code to deserialise data structures
+ * from stdin. Functions from this file are called
+ * by the wrapper.
+ * This code should always be symmetric with serialiser.c!
+ * > serialise(deserialise(str) == str)
+ * - This should either pass, or exit deliberaltely on invalid
+ *   input, but can never silently be "false".
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * Discards the entire leftover stdint buffer.
+ * Not strictly necessary for basic purposes, but should
+ * be called to avoid tricky debugging in the future
+ */
+void _discard_stdin() {
+    char c;
+    while ((c = getchar()) != '\n' && c != EOF)
+        /* Empty */ ;
+}
+
+/**
+ * Errors, clears stdin and exits
+ */
+void _error(char *s) {
+    fprintf(stderr, s);
+    fprintf(stderr, "\n");
+    _discard_stdin();
+    exit(1);
+}
+
+/**
+ * Attempts to read an integer and passes success status
+ */
+bool _try_read_int(int *val) {
+    int status = scanf(" %d", val);
+
+    if (status == 1) return true;
+    else return false;
+
+    // False for both EOF and non-integer stream.
+    // We might want to explicitly check and handle
+    // both cases in the future, but there is no
+    // need for that yet
+}
+
+/**
+ * Reads and returns single int from stdin.
+ * Errors on failure.
+ */
+int _read_int() {
+    int val;
+    if (!_try_read_int(&val)) {
+        _error("could not read integer from stdin");
+    }
+    return val;
+}
+
+/**
+ * Reads and returns a single integer from stdin
+ * Discards extra provided integers
+ */
+int deserialise_single_int() {
+    int num = _read_int();
+    _discard_stdin();
+    return num;
+}

--- a/prototype/skeleton/C/deserialiser.h
+++ b/prototype/skeleton/C/deserialiser.h
@@ -1,0 +1,5 @@
+// deserialiser.h
+
+#pragma once
+
+int deserialise_single_int();

--- a/prototype/skeleton/C/exercises/01_add_one/submission.c
+++ b/prototype/skeleton/C/exercises/01_add_one/submission.c
@@ -1,0 +1,3 @@
+int add_one(int num) {
+    return num + 1;
+}

--- a/prototype/skeleton/C/exercises/01_add_one/submission.h
+++ b/prototype/skeleton/C/exercises/01_add_one/submission.h
@@ -1,0 +1,9 @@
+// submission.h
+
+/**
+ * This file is written by exercise authors.
+ */
+
+#pragma once
+
+int add_one(int num);

--- a/prototype/skeleton/C/exercises/01_add_one/wrapper.c
+++ b/prototype/skeleton/C/exercises/01_add_one/wrapper.c
@@ -1,0 +1,23 @@
+// wrapper.c
+
+/**
+ * This file is written by exercise authors.
+ * It has the following responsibilities:
+ *   - Call the correct, existing deserialiser specific for this exercise
+ *   - Ready all variables for problem entry (deconstructing structs, etc)
+ *   - Call user submission
+ *   - Call serialiser
+ */
+
+#include "../../deserialiser.h"
+#include "../../serialiser.h"
+#include "submission.h"
+
+/**
+ * Entrypoint for code testing. Called by main
+ */
+void wrapper() {
+    int input = deserialise_single_int();
+    int res = add_one(input);
+    serialise_single_int(res);
+}

--- a/prototype/skeleton/C/exercises/01_add_one/wrapper.h
+++ b/prototype/skeleton/C/exercises/01_add_one/wrapper.h
@@ -1,0 +1,9 @@
+// wrapper.h
+
+/**
+ * This file is part of the skeleton and is never changed
+ */
+
+#pragma once
+
+void wrapper();

--- a/prototype/skeleton/C/main.c
+++ b/prototype/skeleton/C/main.c
@@ -1,0 +1,14 @@
+// main.c
+
+/** 
+ * Entry point for code submission framework.
+ * We can do setup or other preparations here, or start a timer.
+ * Calls submission_wrapper.
+ */
+
+ #include "wrapper.h"
+
+int main() {
+    wrapper();
+    return 0;
+}

--- a/prototype/skeleton/C/serialiser.c
+++ b/prototype/skeleton/C/serialiser.c
@@ -1,0 +1,34 @@
+// serialiser.c
+
+/** IMPORTANT:
+ * IF THIS FILE IS MODIFIED IN ANY WAY,
+ * PROPAGATE MODIFICATIONS TO deserialiser.c/.h
+ */
+
+/**
+ * Contains code to serialise data structures
+ * to stdout. Functions from this file are called
+ * by the wrapper.
+ * This code should always be symmetric with deserialiser.c!
+ * > deserialise(serialise(data) == data)
+ * - This should either pass, or exit deliberaltely on invalid
+ *   input, but can never silently be "false".
+ */
+
+#include <stdio.h>
+
+/**
+ * Pushes newline to stdout and flushes buffer.
+ */
+void _finalise() {
+    fputc('\n', stdout);
+    fflush(stdout);
+}
+
+/**
+ * Writes a single integer to stdout
+ */
+void serialise_single_int(int num) {
+    printf("%i", num);
+    _finalise();
+}

--- a/prototype/skeleton/C/serialiser.h
+++ b/prototype/skeleton/C/serialiser.h
@@ -1,0 +1,5 @@
+// serialiser.h
+
+#pragma once
+
+void serialise_single_int(int num);


### PR DESCRIPTION
Discussed in #18 
Closes #66 

A first iteration of a code skeleton that can be used for submission checking. The code is split in three parts, with distinct purposes.
- Base Framework
  - Never changed, works for every C submission, ever. 
  - As general as possible. Contains helper libraries that serialise/deserialise data, and a `main` entrypoint.
  - Calls the wrapper
  - Does NOT check test output validity
- Wrapper
  - Needs to be implemented for every exercise
  - Created and modified by exercise authors.
  - Can only use the `include` keyword on the serialiser, deserialiser and submission headers (security)
    - Can be easily enforced with a security Python script
    - To avoid getting around this limitation, we may have to ban `#define` too.
    - Future helpers needed in wrapper need to be added to the base framework
  - As small as possible, only calls helper functions and prepares data format for exercise
  - Deserialises test inputs from stdin
  - Serialises test outputs from stdout
  - Does NOT check test output validity
- Submission
  - Submitted by the user
  - Cannot `include` any headers (security)
    - Easily enforced using a security Python script
  - Can contain extra functions, but must at least contain the entrypoint function for the wrapper to work

Output validity can be implemented by running the program on every line on the test input file, writing a test output file, which can then be compared to the expected output file.

Runtime timing not yet included, we might choose to make the base framework perform timings and add those to extra output file timings.txt (avoids the bash overhead of starting each program)