### PR TITLE
Change JWT expire time to 4 hours

### DIFF
--- a/db/src/db/config.py
+++ b/db/src/db/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     # JWT
     JWT_SECRET_KEY: str = "0123456789abcdef"
     JWT_ALGORITHM: str = "HS256"
-    TOKEN_EXPIRE_MINUTES: int = 30
+    TOKEN_EXPIRE_MINUTES: int = 240
 
 
 settings = Settings()


### PR DESCRIPTION
A problem should be easily solvable in four hours. If you have to leave in the middle of a problem this gives a plausible window to return and continue, but if you are gone for longer you wouldn't be surprised to have to log in again. 